### PR TITLE
CI: update actions and arch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
-      - uses: julia-actions/cache@v4
+      - uses: julia-actions/cache@v3
       - name: Build package manually
         run: |
           using Pkg

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
-      - uses: julia-actions/cache@v3
+      - uses: julia-actions/cache@v4
       - name: Build package manually
         run: |
           using Pkg
@@ -60,7 +60,7 @@ jobs:
   #     - uses: julia-actions/setup-julia@v3
   #       with:
   #         version: '1'
-  #     - uses: julia-actions/cache@v3
+  #     - uses: julia-actions/cache@v4
   #     - name: Configure doc environment
   #       shell: julia --project=docs --color=yes {0}
   #       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
@@ -27,14 +27,11 @@ jobs:
           - '1'
         os:
           - ubuntu-latest
-        arch:
-          - x64
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
       - name: Build package manually
         run: |
@@ -60,7 +57,7 @@ jobs:
   #     statuses: write
   #   steps:
   #     - uses: actions/checkout@v6
-  #     - uses: julia-actions/setup-julia@v2
+  #     - uses: julia-actions/setup-julia@v3
   #       with:
   #         version: '1'
   #     - uses: julia-actions/cache@v3


### PR DESCRIPTION
`macOS-latest` GitHub runners are now Apple Silicon (arm64). `setup-julia@v3` errors when `arch: x64` is requested on them, so the macOS jobs fail.

This configures the matrix to use the correct native architecture (default per-runner for single-arch matrices; explicit `exclude`/`include` for multi-arch matrices) and bumps `julia-actions/setup-julia` to v3.
