### PR TITLE
Transiently strip HpN for registration

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,14 +33,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
       - uses: julia-actions/cache@v3
-      - name: Build package manually
-        run: |
-          using Pkg
-          Pkg.add([
-            PackageSpec(url="https://github.com/timholy/HemiplexNumbers.jl.git"),
-            ])
-          Pkg.build()
-        shell: julia --color=yes --project="@." {0}
+      - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7
@@ -48,34 +41,3 @@ jobs:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
-  # docs:
-  #   name: Documentation
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     actions: write # needed to allow julia-actions/cache to proactively delete old caches that it has created
-  #     contents: write
-  #     statuses: write
-  #   steps:
-  #     - uses: actions/checkout@v7
-  #     - uses: julia-actions/setup-julia@v3
-  #       with:
-  #         version: '1'
-  #     - uses: julia-actions/cache@v4
-  #     - name: Configure doc environment
-  #       shell: julia --project=docs --color=yes {0}
-  #       run: |
-  #         using Pkg
-  #         Pkg.develop(PackageSpec(path=pwd()))
-  #         Pkg.instantiate()
-  #     - uses: julia-actions/julia-buildpkg@v1
-  #     - uses: julia-actions/julia-docdeploy@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-  #     - name: Run doctests
-  #       shell: julia --project=docs --color=yes {0}
-  #       run: |
-  #         using Documenter: DocMeta, doctest
-  #         using HemiplexFactorizations
-  #         DocMeta.setdocmeta!(HemiplexFactorizations, :DocTestSetup, :(using HemiplexFactorizations); recursive=true)
-  #         doctest(HemiplexFactorizations)

--- a/Project.toml
+++ b/Project.toml
@@ -4,13 +4,11 @@ version = "1.0.0"
 authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
 
 [deps]
-HemiplexNumbers = "0a1bf870-1ec7-454f-b2b3-83307695f2d3"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 DoubleFloats = "1"
-HemiplexNumbers = "1"
 LinearAlgebra = "1"
 SparseArrays = "1"
 julia = "1.10"


### PR DESCRIPTION
I'd rather co-register HemiplexNumbers (HpN) and HemiplexFactorizations (HpF), but this isn't supported and the 3-day registration window is annoyingly long. So as a device, make the two packages independent of one another so I can get the timers for both started. I'll fix this package up once the HpN registration has merged.